### PR TITLE
Add shortMessagePattern configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ changed from 0.9.5 -> 0.9.6. Allowed values = 0.9.5 and 0.9.6. Defaults to "0.9.
 smaller packets. Defaults to 1000
 *   **messagePattern**: The layout of the actual message according to
 [PatternLayout](http://logback.qos.ch/manual/layouts.html#conversionWord). Defaults to "%m%rEx"
+*   **shortMessagePattern**: The layout of the short message according to
+[PatternLayout](http://logback.qos.ch/manual/layouts.html#conversionWord). Defaults to none which means the message will
+be truncated to create the short message
 *   **additionalFields**: See additional fields below. Defaults to empty
 *   **staticAdditionalFields**: See static additional fields below. Defaults to empty
 *   **includeFullMDC**: See additional fields below. Defaults to false

--- a/src/main/java/me/moocar/logbackgelf/GelfAppender.java
+++ b/src/main/java/me/moocar/logbackgelf/GelfAppender.java
@@ -29,6 +29,7 @@ public class GelfAppender extends AppenderBase<ILoggingEvent> {
     private String graylog2ServerVersion = "0.9.6";
     private int chunkThreshold = 1000;
     private String messagePattern = "%m%rEx";
+    private String shortMessagePattern = null;
     private Map<String, String> additionalFields = new HashMap<String, String>();
     private Map<String, String> staticAdditionalFields = new HashMap<String, String>();
     private boolean includeFullMDC;
@@ -99,7 +100,8 @@ public class GelfAppender extends AppenderBase<ILoggingEvent> {
                     new ChunkFactory(chunkedGelfId, padSeq));
 
             GelfConverter converter = new GelfConverter(facility, useLoggerName, useThreadName, additionalFields,
-                    staticAdditionalFields, shortMessageLength, hostname, messagePattern, includeFullMDC);
+                    staticAdditionalFields, shortMessageLength, hostname, messagePattern, shortMessagePattern,
+                    includeFullMDC);
 
             appenderExecutor = new AppenderExecutor(transport, payloadChunker, converter, new Zipper(), chunkThreshold);
 
@@ -321,5 +323,13 @@ public class GelfAppender extends AppenderBase<ILoggingEvent> {
 
     public void setMessagePattern(String messagePattern) {
         this.messagePattern = messagePattern;
+    }
+
+    public String getShortMessagePattern() {
+        return shortMessagePattern;
+    }
+
+    public void setShortMessagePattern(String shortMessagePattern) {
+        this.shortMessagePattern = shortMessagePattern;
     }
 }


### PR DESCRIPTION
As an alternative to truncating the full message to create a short message
you can use logback's pattern layout to construct the short message.  This
gives far more flexibility in terms of what gets constructed.
