### PR TITLE
Reverted change d8101729711ac6aab9b2e7072dda06856df99abd.

### DIFF
--- a/src/main/java/me/moocar/logbackgelf/Transport.java
+++ b/src/main/java/me/moocar/logbackgelf/Transport.java
@@ -17,8 +17,6 @@ public class Transport {
 
     private final InetAddress graylog2ServerAddress;
     private final int graylog2ServerPort;
-    private final SocketAddress loopbackAddress = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).indexOf("windows") > -1 ?
-        new InetSocketAddress("localhost", 0) : new InetSocketAddress(0);
 
     public Transport(int graylog2ServerPort, InetAddress graylog2ServerAddress) {
         this.graylog2ServerPort = graylog2ServerPort;
@@ -72,7 +70,7 @@ public class Transport {
 
         try {
 
-            return new DatagramSocket(loopbackAddress);
+            return new DatagramSocket();
 
         } catch (SocketException ex) {
 


### PR DESCRIPTION
The timeout fix for Windows effectively disabled all logging from a windows clients (mostly development machines).
An integration test was performed to verify if the timeout could actually be reproduced, but this was not the case.
It is unclear why this was occured previously.
