### PR TITLE
Use FQDN if possible.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,24 @@
       <version>14.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-module-junit4</artifactId>
+        <version>1.5.4</version>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-api-mockito</artifactId>
+        <version>1.5.4</version>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>1.8.5</version>
+        <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/me/moocar/logbackgelf/util/InternetUtils.java
+++ b/src/main/java/me/moocar/logbackgelf/util/InternetUtils.java
@@ -15,6 +15,8 @@ import java.net.SocketException;
 import java.net.UnknownHostException;
 
 public class InternetUtils {
+    private static final String REGEX_IP_ADDRESS = "\\d+(\\.\\d+){3}";
+
     private InternetUtils() {
     }
 
@@ -23,7 +25,11 @@ public class InternetUtils {
      */
     public static String getLocalHostName() throws SocketException, UnknownHostException {
         try {
-            return InetAddress.getLocalHost().getCanonicalHostName();
+            final String canonicalHostName = InetAddress.getLocalHost().getCanonicalHostName();
+            if (canonicalHostName.contains(".") && !canonicalHostName.matches(REGEX_IP_ADDRESS)) {
+                return canonicalHostName;
+            }
+            return InetAddress.getLocalHost().getHostName();
         } catch (UnknownHostException e) {
             NetworkInterface networkInterface = NetworkInterface.getNetworkInterfaces().nextElement();
             if (networkInterface == null) throw e;

--- a/src/test/java/me/moocar/logbackgelf/util/InternetUtilsTest.java
+++ b/src/test/java/me/moocar/logbackgelf/util/InternetUtilsTest.java
@@ -1,0 +1,59 @@
+package me.moocar.logbackgelf.util;
+
+import java.net.InetAddress;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(InternetUtils.class)
+public class InternetUtilsTest {
+	private static final String RESULT_HOSTNAME = "hostname";
+	private static final String RESULT_FQDN = "hostname.with.do-main";
+	private static final String RESULT_IP = "1.2.3.4";
+
+	@Mock
+	private InetAddress myAddress;
+
+	@Before
+	public void setUp() throws UnknownHostException {
+		PowerMockito.mockStatic(InetAddress.class);
+		PowerMockito.when(InetAddress.getLocalHost()).thenReturn(myAddress);
+	}
+
+	@Test
+	public void testHostFQDN() throws UnknownHostException, SocketException {
+		PowerMockito.when(myAddress.getHostName()).thenReturn(RESULT_HOSTNAME);
+		PowerMockito.when(myAddress.getCanonicalHostName()).thenReturn(RESULT_FQDN);
+		Assert.assertEquals(RESULT_FQDN, InternetUtils.getLocalHostName());
+	}
+
+	@Test
+	public void testHostIP() throws UnknownHostException, SocketException {
+		PowerMockito.when(myAddress.getHostName()).thenReturn(RESULT_HOSTNAME);
+		PowerMockito.when(myAddress.getCanonicalHostName()).thenReturn(RESULT_IP);
+		Assert.assertEquals(RESULT_HOSTNAME, InternetUtils.getLocalHostName());
+	}
+
+	@Test
+	public void testFQDNIP() throws UnknownHostException, SocketException {
+		PowerMockito.when(myAddress.getHostName()).thenReturn(RESULT_FQDN);
+		PowerMockito.when(myAddress.getCanonicalHostName()).thenReturn(RESULT_IP);
+		Assert.assertEquals(RESULT_FQDN, InternetUtils.getLocalHostName());
+	}
+
+	@Test
+	public void testIPFQDN() throws UnknownHostException, SocketException {
+		PowerMockito.when(myAddress.getHostName()).thenReturn(RESULT_IP);
+		PowerMockito.when(myAddress.getCanonicalHostName()).thenReturn(RESULT_FQDN);
+		Assert.assertEquals(RESULT_FQDN, InternetUtils.getLocalHostName());
+	}
+}


### PR DESCRIPTION
I have the problem that some systems are logged with their hostname only and others with the FQDN in our Graylog2. We have a test and a live net, which can be distinguished by their subdomain and I need that to separate the logging.
I did some tests with the getCanonicalHostName method on different systems and it always gave the FQDN, so that is the right solution for us.
It would be nice if that could be integrated in the next release.
