### PR TITLE
Gelf and UTF-8

### DIFF
--- a/src/main/java/me/moocar/logbackgelf/Zipper.java
+++ b/src/main/java/me/moocar/logbackgelf/Zipper.java
@@ -17,7 +17,7 @@ public class Zipper {
         try {
             ByteArrayOutputStream targetStream = new ByteArrayOutputStream();
             zipStream = new GZIPOutputStream(targetStream);
-            zipStream.write(str.getBytes());
+            zipStream.write(str.getBytes("UTF-8"));
             zipStream.close();
             byte[] zipped = targetStream.toByteArray();
             targetStream.close();


### PR DESCRIPTION
The GELF spec (http://www.graylog2.org/resources/gelf/specification) specifies that strings should be encoded as UTF8, String.getBytes() uses the platform default encoding which is not always UTF-8. This patch fixes it by forcing the use of UTF-8.
