### PR TITLE
Making clojure dependencies under the "test" scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,47 +59,54 @@
       <artifactId>gson</artifactId>
       <version>2.3.1</version>
     </dependency>
+    <dependency>
+      <groupId>me.moocar</groupId>
+      <artifactId>socket-encoder-appender</artifactId>
+      <version>0.1beta1</version>
+    </dependency>
 
     <!-- Clojure Test dependencies -->
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
       <version>1.7.0-alpha5</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>core.async</artifactId>
       <version>0.1.346.0-17112a-alpha</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>data.json</artifactId>
       <version>0.2.6</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>data.xml</artifactId>
       <version>0.0.8</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>test.check</artifactId>
       <version>0.7.0</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>tools.nrepl</artifactId>
       <version>0.2.10</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.stuartsierra</groupId>
       <artifactId>component</artifactId>
       <version>0.2.3</version>
-    </dependency>
-    <dependency>
-      <groupId>me.moocar</groupId>
-      <artifactId>socket-encoder-appender</artifactId>
-      <version>0.1beta1</version>
+      <scope>test</scope>
     </dependency>
 
     <!-- Java Test dependencies -->
@@ -124,7 +131,7 @@
     <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>1.10.9</version>
+        <version>1.10.19</version>
         <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
I've made this adjustment so that anyone who is relying on this dependency from maven central will not have to transitively include the jars used exclusively for testing (including the com.stuartsierra one that cannot be resolved without adding additional maven repositories).

I also moved up the socket-encoder-appender to be under the production dependencies section (cleanup).