### PR TITLE
Appender should recover from io exception

### DIFF
--- a/src/main/java/me/moocar/logbackgelf/GelfUDPAppender.java
+++ b/src/main/java/me/moocar/logbackgelf/GelfUDPAppender.java
@@ -92,8 +92,12 @@ public class GelfUDPAppender<E> extends OutputStreamAppender<E> {
     }
 
     @Override
-    protected void writeOut(E event) throws IOException {
-        super.writeOut(event);
+    protected void writeOut(E event) {
+        try {
+            super.writeOut(event);
+        } catch (IOException e) {
+            addError("IO Exception in UDP output stream", e);
+        }
     }
 
     /**

--- a/src/test/clojure/me/moocar/logbackgelf/appender_test.clj
+++ b/src/test/clojure/me/moocar/logbackgelf/appender_test.clj
@@ -1,0 +1,65 @@
+(ns me.moocar.logbackgelf.appender-test
+  (:require [clojure.core.async :as async :refer [<!!]]
+            [clojure.test :refer [run-tests deftest is testing]]
+            [me.moocar.logbackgelf.system :as system])
+  (:import (ch.qos.logback.core.encoder LayoutWrappingEncoder)
+           (java.io OutputStream IOException)
+           (me.moocar.logbackgelf GelfUDPAppender GelfLayout)
+           (org.slf4j LoggerFactory)))
+
+(defn- new-throwing-output-stream []
+  (proxy [OutputStream] []
+    (write [b]
+      (throw (IOException. "Excepted exception")))))
+
+(defn- new-udp-appender [context config encoder]
+  (doto (GelfUDPAppender.)
+    (.setContext context)
+    (.setPort (:port (:appender config)))
+    (.setEncoder encoder)
+    (.start)))
+
+(defn- new-layout [context]
+  (doto (GelfLayout.)
+    (.setContext context)
+    (.start)))
+
+(defn- new-layout-encoder [context layout]
+  (doto (LayoutWrappingEncoder.)
+    (.setContext context)
+    (.setLayout layout)
+    (.start)))
+
+(defn- build-appender [config]
+  (let [context (doto (LoggerFactory/getILoggerFactory)
+                  (.reset))
+        gelf-layout (new-layout context)
+        encoder (new-layout-encoder context gelf-layout)]
+    (new-udp-appender context config encoder)))
+
+(deftest t-io-exception-not-fatal
+  (testing "when an IO exception is thrown in the output stream
+  append, make sure that future appends still complete. I.e it should recover"
+    (system/fixture
+     [system (system/make-config)]
+     (let [{:keys [config server]} system
+           appender (build-appender config)
+           gelf-output-stream (.getOutputStream appender)
+           throwing-output-stream (new-throwing-output-stream)
+           logger (doto (LoggerFactory/getLogger "this_logger")
+                    (.addAppender appender))
+           msg-ch (:msg-ch server)]
+
+       (.debug logger "msg 1")
+       (.setOutputStream appender throwing-output-stream)
+       (.debug logger "msg 2")
+       (.setOutputStream appender gelf-output-stream)
+       (.debug logger "msg 3")
+
+       (is (= ["msg 1" "msg 3"]
+              (->> msg-ch
+                   (async/take 2)
+                   (async/into [])
+                   <!!
+                   (map :full_message)))
+           "msg 2 should not succeed, but msg 3 should work again")))))

--- a/src/test/clojure/me/moocar/logbackgelf/servers.clj
+++ b/src/test/clojure/me/moocar/logbackgelf/servers.clj
@@ -119,10 +119,16 @@
                 {:keys [length offset data]} packet]
             (if (chunked? packet)
               (let [[chunks full-packet] (process-chunk chunks (dechunk packet))]
-                (when full-packet
-                  (>!! msg-ch (packet->json full-packet)))
+                (try
+                  (when full-packet
+                    (>!! msg-ch (packet->json full-packet)))
+                  (catch Throwable t
+                    (.printStackTrace t)))
                 (recur chunks))
-              (do (>!! msg-ch (packet->json packet))
+              (do (try
+                    (>!! msg-ch (packet->json packet))
+                    (catch Throwable t
+                      (.printStackTrace t)))
                   (recur chunks)))))))))
 
 (defn new-datagram-socket-reader

--- a/src/test/clojure/me/moocar/logbackgelf/system.clj
+++ b/src/test/clojure/me/moocar/logbackgelf/system.clj
@@ -1,0 +1,44 @@
+(ns me.moocar.logbackgelf.system
+  (:require [clojure.core.async :as async]
+            [com.stuartsierra.component :as component]
+            [me.moocar.logbackgelf.servers :as servers])
+  (:import (org.slf4j LoggerFactory)))
+
+(defn make-config
+  []
+  {:full-message-pattern "%rEx%m"
+   :short-message-pattern "%rEx%m"
+   :use-logger-name? true
+   :use-marker? true
+   :host "Test"
+   :version "1.1"
+   :debug? false
+   :appender {:type :udp
+              :port 12202}
+   :static-additional-fields {"_facility" "logback-gelf-test"}
+   :include-full-mdc? true})
+
+(defn new-test-system
+  [config]
+  (component/system-map
+   :server (servers/new-test-server config (async/chan 100))
+   :config config))
+
+(defmacro with-test-system
+  "Starts a new system"
+  [[binding-form system-map] & body]
+  `(let [system# (component/start ~system-map)
+         ~binding-form system#]
+     (try ~@body
+          (finally
+            (component/stop system#)))))
+
+(defmacro fixture [[binding-form config] & body]
+  `(let [config# ~config]
+     (with-test-system [system# (new-test-system config#)]
+       (let [~binding-form system#]
+         (try
+           ~@body
+           (finally
+             (.stop (LoggerFactory/getILoggerFactory))))))))
+


### PR DESCRIPTION
Fixes a bug where if an IO exception was thrown in the output stream, the GelfUDPAppender would never recover. Also refactored tests to pull common system functionality into its own ns.