### PR TITLE
Add static fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,11 @@ default values:
                 <additionalField>requestId:_request_id</additionalField>
                 <includeFullMDC>true</includeFullMDC>
                 <fieldType>_request_id:long</fieldType>
-                <!--Facility is not officially supported in GELF anymore, but you can use staticAdditionalFields to do the same thing-->
-                <staticAdditionalField>_facility:GELF</staticAdditionalField>
+                <!--Facility is not officially supported in GELF anymore, but you can use staticFields to do the same thing-->
+                <staticField class="me.moocar.logbackgelf.Field">
+                  <key>_facility</key>
+                  <value>GELF</value>
+                </staticField>
             </layout>
         </encoder>
     </appender>
@@ -92,6 +95,7 @@ default values:
     </root>
 </configuration>
 ```
+
 ## GelfLayout
 
 `me.moocar.logbackgelf.GelfLayout`
@@ -126,9 +130,10 @@ actually converts a log event into a GELF compatible JSON string.
 * **additionalFields**: See additional fields below. Default: empty
 * **fieldType**: See field type conversion below. Default: empty
   (fields sent as string)
-* **staticAdditionalFields**: See static additional fields below.
-  Note, now that facility is deprecated, use this to set a facility
-  Default: empty
+* **staticFields**: See static fields below. Note, now that facility
+  is deprecated, use this to set a facility Default: empty
+* **staticAdditionalFields**: _deprecated_. Use staticFields. Default:
+  empty
 * **includeFullMDC**: See additional fields below. Default: `false`
 
 ## Transports
@@ -247,23 +252,36 @@ If the property `includeFullMDC` is set to false (default value) then
 only the keys listed as `additionalField` will be added to a gelf
 message.
 
-### Static Additional Fields
+### Static Fields
 
 Use static additional fields when you want to add a static key value
 pair to every GELF message. Key is the additional field key (and
 should thus begin with an underscore). The value is a static string.
 
 Now that the GELF `facility` is deprecated, this is how you add a
-static facility.
+static facility. StaticFields replace staticAdditionalFields
 
 E.g in the appender configuration:
 
 ```xml
 <layout class="me.moocar.logbackgelf.GelfLayout">
-    <staticAdditionalField>_node_name:www013</staticAdditionalField>
-    <staticAdditionalField>_facility:GELF</staticAdditionalField>
+  <staticField class="me.moocar.logbackgelf.Field">
+    <key>_facility</key>
+    <value>GELF</value>
+  </staticField>
+  <staticField class="me.moocar.logbackgelf.Field">
+    <key>_node_name</key>
+    <value>www013</value>
+  </staticField>
 </layout>
 ```
+
+### Static Additional Fields (deprecated)
+
+Static Additional fields have been deprecated and superceded by
+staticFields. While they offered a more concise way of expressing the
+key/value pair, it was impossible to include a colon in the value.
+staticFields are fully structured and don't have this problem.
 
 ### Field type conversion
 

--- a/sample.logback.xml
+++ b/sample.logback.xml
@@ -21,7 +21,7 @@
                 <additionalField>requestId:_request_id</additionalField>
                 <includeFullMDC>true</includeFullMDC>
                 <fieldType>_request_id:long</fieldType>
-                <!--Facility is not officially supporte in GELF anymore, but you can use staticAdditionalFields to do the same thing-->
+                <!--Facility is not officially supported in GELF anymore, but you can use staticAdditionalFields to do the same thing-->
                 <staticAdditionalField>_facility:GELF</staticAdditionalField>
             </layout>
         </encoder>

--- a/sample.logback.xml
+++ b/sample.logback.xml
@@ -22,7 +22,10 @@
                 <includeFullMDC>true</includeFullMDC>
                 <fieldType>_request_id:long</fieldType>
                 <!--Facility is not officially supported in GELF anymore, but you can use staticAdditionalFields to do the same thing-->
-                <staticAdditionalField>_facility:GELF</staticAdditionalField>
+                <staticField class="me.moocar.logbackgelf.Field">
+                  <key>_facility</key>
+                  <value>GELF</value>
+                </staticField>
             </layout>
         </encoder>
     </appender>

--- a/src/main/java/me/moocar/logbackgelf/Field.java
+++ b/src/main/java/me/moocar/logbackgelf/Field.java
@@ -1,0 +1,7 @@
+package me.moocar.logbackgelf;
+
+/**
+ * Created by anthony on 7/7/15.
+ */
+public class Field {
+}

--- a/src/main/java/me/moocar/logbackgelf/Field.java
+++ b/src/main/java/me/moocar/logbackgelf/Field.java
@@ -1,7 +1,23 @@
 package me.moocar.logbackgelf;
 
-/**
- * Created by anthony on 7/7/15.
- */
 public class Field {
+
+    private String key;
+    private String value;
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
 }

--- a/src/test/clojure/me/moocar/logbackgelf/end_to_end_test.clj
+++ b/src/test/clojure/me/moocar/logbackgelf/end_to_end_test.clj
@@ -301,7 +301,4 @@
     (let [logger (LoggerFactory/getLogger "this_logger")]
       (dotimes [_ 10]
         (future (.debug logger (string/join (repeatedly (* 512 5) #(rand-nth "abcdefghijklmnopqrstuvwxyz"))) #_(ex-info "ERROR ME TIMBER" {}))))
-      (.debug logger (string/join (repeatedly 30 #(rand-nth "abcdefghijklmnopqrstuvwxyz"))) #_(ex-info "ERROR ME TIMBER" {})))))
-
-(send-request)
-;; (require 'me.moocar.logbackgelf.end-to-end-test)
+      #_(.debug logger (string/join (repeatedly 30 #(rand-nth "abcdefghijklmnopqrstuvwxyz"))) #_(ex-info "ERROR ME TIMBER" {})))))

--- a/src/test/clojure/me/moocar/logbackgelf/end_to_end_test.clj
+++ b/src/test/clojure/me/moocar/logbackgelf/end_to_end_test.clj
@@ -62,8 +62,12 @@
           [:additionalField "ipAddress:_ip_address"]
           [:additionalField "requestId:_request_id"]
           [:includeFullMDC (:include-full-mdc? config)]]
-         (map #(vector :staticAdditionalField (string/join ":" %))
-              (:static-additional-fields config))
+         (for [field (:static-additional-fields config)]
+           [:staticAdditionalField (string/join ":" field)])
+         (for [field (:static-fields config)]
+           [:staticField {:class "me.moocar.logbackgelf.Field"}
+            [:key (key field)]
+            [:value (val field)]])
          (map #(vector :fieldType (string/join ":" %))
               (:field-types config))))]]
      [:root {:level "all"}
@@ -236,6 +240,17 @@
       (let [json (wait msg-ch)]
         (is (= "www013" (:_node_name json)))))))
 
+(defn t-static-fields
+  [{:keys [config server] :as system}]
+  (let [msg-ch (:msg-ch server)
+        config (assoc config :static-fields {"foo" "bar"
+                                             "moo" "car"})]
+    (with-logger [logger config]
+      (.debug logger "my msg")
+      (let [json (wait msg-ch)]
+        (is (= "bar" (:foo json)))
+        (is (= "car" (:moo json)))))))
+
 (defn t-undefined-hostname-string
   "Ensure that when a bad remote host is included, that an
   appropariate error is reported to the user. Note that I can't think
@@ -270,6 +285,7 @@
    (t-substitute system)
    (t-exception system)
    (t-static-additional-field system)
+   (t-static-fields system)
    (t-undefined-hostname-string system)
    (is (= true (:result (tc/quick-check 100 (t-field-types system)))))
    (is (= true (:result (tc/quick-check 100 (t-test system)))))))
@@ -285,4 +301,7 @@
     (let [logger (LoggerFactory/getLogger "this_logger")]
       (dotimes [_ 10]
         (future (.debug logger (string/join (repeatedly (* 512 5) #(rand-nth "abcdefghijklmnopqrstuvwxyz"))) #_(ex-info "ERROR ME TIMBER" {}))))
-      #_(.debug logger (string/join (repeatedly 30 #(rand-nth "abcdefghijklmnopqrstuvwxyz"))) #_(ex-info "ERROR ME TIMBER" {})))))
+      (.debug logger (string/join (repeatedly 30 #(rand-nth "abcdefghijklmnopqrstuvwxyz"))) #_(ex-info "ERROR ME TIMBER" {})))))
+
+(send-request)
+;; (require 'me.moocar.logbackgelf.end-to-end-test)


### PR DESCRIPTION
Addresses #55 by making static fields structured instead of relying on colon parsing. Thankfully the name `staticField` wasn't taken so `staticAdditionalField` is now deprecated. Read README changes for more info.

Note, it would be really nice if the user didn't have to enter the class `me.moocar.logbackgelf.Field` manually each time, but after having perused through the logback documentation, I'm not aware of how to do this.