### PR TITLE
Add source port option to GelfUDPAppender

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ size, this allows for 65536 bytes (64kb) total per log message
 * **remoteHost**: The remote graylog server host to send log messages
   to (DNS or IP). Default: `"localhost"`
 * **port**: The remote graylog server port. Default: `12201`
+* **srcPort**: The source port on the local machine. Default: `0` (ephemeral
+  port)
 * **maxPacketSize**: The maximum number of bytes per datagram packet.
   Once the limit is reached, packets will be chunked. Default: `512`
 

--- a/src/main/java/me/moocar/logbackgelf/GelfChunkingOutputStream.java
+++ b/src/main/java/me/moocar/logbackgelf/GelfChunkingOutputStream.java
@@ -34,6 +34,7 @@ public class GelfChunkingOutputStream extends OutputStream {
 
     private final InetAddress address;
     private final int port;
+    private final int srcPort;
     private DatagramSocket socket;
 
     // When in chunking mode, this is the index of the chunk that we are currently writing bytes to
@@ -53,21 +54,22 @@ public class GelfChunkingOutputStream extends OutputStream {
      *
      * @param address The address of the remove server
      * @param port The port of the remote server
+     * @param srcPort The source port on the local machine (use 0 for ephemeral port)
      * @param maxPacketSize The maximum number of bytes allowed before chunking begins
      * @param messageIdProvider A object that generates totally unique (for this machine) 8-byte message IDs.
      */
-    public GelfChunkingOutputStream(InetAddress address, int port, int maxPacketSize, MessageIdProvider messageIdProvider) {
+    public GelfChunkingOutputStream(InetAddress address, int port, int srcPort, int maxPacketSize, MessageIdProvider messageIdProvider) {
         this.address = address;
         this.port = port;
+        this.srcPort = srcPort;
         this.maxPacketSize = maxPacketSize;
         this.messageIdProvider = messageIdProvider;
         this.chunks = new byte[MAX_CHUNKS][maxPacketSize];
         this.packetBytes = new byte[maxPacketSize];
     }
 
-
     public void start() throws SocketException, UnknownHostException {
-        this.socket = new DatagramSocket();
+        this.socket = new DatagramSocket(srcPort);
         this.socket.connect(address, port);
     }
 

--- a/src/main/java/me/moocar/logbackgelf/GelfUDPAppender.java
+++ b/src/main/java/me/moocar/logbackgelf/GelfUDPAppender.java
@@ -18,10 +18,12 @@ public class GelfUDPAppender<E> extends OutputStreamAppender<E> {
 
     private final String REMOTE_HOST = "localhost";
     private final int DEFAULT_PORT = 12201;
+    private final int DEFAULT_SRC_PORT = 0;
     private final int DEFAULT_MAX_PACKET_SIZE = 512;
 
     private String remoteHost = REMOTE_HOST;
     private int port = DEFAULT_PORT;
+    private int srcPort = DEFAULT_SRC_PORT;
     private int maxPacketSize = DEFAULT_MAX_PACKET_SIZE;
 
     @Override
@@ -76,7 +78,7 @@ public class GelfUDPAppender<E> extends OutputStreamAppender<E> {
         }
 
         if (errorCount == 0) {
-            GelfChunkingOutputStream os = new GelfChunkingOutputStream(address, port, maxPacketSize, messageIdProvider);
+            GelfChunkingOutputStream os = new GelfChunkingOutputStream(address, port, srcPort, maxPacketSize, messageIdProvider);
             try {
                 os.start();
                 this.setOutputStream(os);
@@ -120,6 +122,18 @@ public class GelfUDPAppender<E> extends OutputStreamAppender<E> {
 
     public void setPort(int port) {
         this.port = port;
+    }
+
+    /**
+     * The source port on the local machine. Defaults to 0 (ephemeral port)
+     * @see java.net.InetSocketAddress#InetSocketAddress(int port)
+     */
+    public int getSrcPort() {
+        return srcPort;
+    }
+
+    public void setSrcPort(int srcPort) {
+        this.srcPort = srcPort;
     }
 
     /**


### PR DESCRIPTION
For performance purposes, we want to specify the source port of UDP packets (to use a load balancer with a connection table). Can you merge this improvement?

Thank you